### PR TITLE
Remove the webmock disable_net_connect call

### DIFF
--- a/lib/fake_stripe/initializers/webmock.rb
+++ b/lib/fake_stripe/initializers/webmock.rb
@@ -1,4 +1,3 @@
 require 'webmock'
 include WebMock::API
 WebMock.enable!
-WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
believe this is interfering with knapsackpro making an API call on and can't figure out how to turn it off so trying it forcefully