### PR TITLE
remove the webmock initializers file

### DIFF
--- a/lib/fake_stripe/initializers/webmock.rb
+++ b/lib/fake_stripe/initializers/webmock.rb
@@ -1,3 +1,0 @@
-require 'webmock'
-include WebMock::API
-WebMock.enable!


### PR DESCRIPTION
Let callers set up webmock in their own init code.